### PR TITLE
Fix extension cardinality conflict in domainReference

### DIFF
--- a/ressourcen-profile/Profile_MII_Consent_Einwilligung.xml
+++ b/ressourcen-profile/Profile_MII_Consent_Einwilligung.xml
@@ -72,6 +72,7 @@
     </element>
     <element id="Consent.extension:domainReference.extension">
       <path value="Consent.extension.extension" />
+      <min value="1" />
       <slicing>
         <discriminator>
           <type value="value" />


### PR DESCRIPTION
## Summary

- Fix FHIR Validator error: `Consent.extension:domainReference.extension` has `min=0` but the required slice `domain` has `min=1`
- Set `<min value="1" />` on the slicing element to match

## Problem

The HL7 FHIR Validator (6.7.10) reports:

> The slice definition for Consent.extension:domainReference.extension has a minimum of 0 but the slices add up to a minimum of 1

This is the same class of bug as [kerndatensatzmodul-biobank PR #71](https://github.com/medizininformatik-initiative/kerndatensatzmodul-biobank/pull/71).

## Test plan

- [ ] Validate `Profile_MII_Consent_Einwilligung` with HL7 FHIR Validator — error should be gone
- [ ] Publish updated package after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)